### PR TITLE
Bugfix: Inconsistent case transformations

### DIFF
--- a/Classes/LanguageDetection.php
+++ b/Classes/LanguageDetection.php
@@ -446,7 +446,7 @@ class LanguageDetection extends AbstractPlugin
             $languageCodesArr = array_keys($acceptedLanguagesArr);
             if (is_array($languageCodesArr)) {
                 foreach ($languageCodesArr as $languageCode) {
-                    $languagesArr[$languageCode] = $languageCode;
+                    $languagesArr[strtolower($languageCode)] = strtolower($languageCode);
                 }
             }
         }


### PR DESCRIPTION
In line 449, the array is filled without lowering the case of the
"accepted languages", as it is done for the "available languages"
in lines 467, 481, 483 and 489.

Therefore a comparison of the "available languages" and "accepted languages"
in line 190 can wrongly fail, if the language-code is longer than a 2-char
iscode, for example "en-US" instead of "en" (value of $acceptedLanguagesArr).

The solution is to lower the case for array-keys and array-values in line 449.